### PR TITLE
Add feedstock/requirements.txt

### DIFF
--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,0 +1,5 @@
+xarray
+fsspec
+kerchunk
+pangeo-forge-cmr
+pangeo-forge-recipes


### PR DESCRIPTION
Got this error when trying to run the repo:
 
```
~/Downloads/pangeo-forge-se-tim on  main ⌚ 13:42:57
$ pangeo-forge-runner bake --repo=. --Bake.job_name="gpm-zarr" --Bake.recipe_id="gpm-zarr" --prune
Traceback (most recent call last):
  File "/Users/lsterzin/miniconda3/envs/work/bin/pangeo-forge-runner", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/lsterzin/miniconda3/envs/work/lib/python3.11/site-packages/pangeo_forge_runner/cli.py", line 28, in main
    app.start()
  File "/Users/lsterzin/miniconda3/envs/work/lib/python3.11/site-packages/pangeo_forge_runner/cli.py", line 23, in start
    super().start()
  File "/Users/lsterzin/miniconda3/envs/work/lib/python3.11/site-packages/traitlets/config/application.py", line 475, in start
    return self.subapp.start()
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/lsterzin/miniconda3/envs/work/lib/python3.11/site-packages/pangeo_forge_runner/commands/bake.py", line 174, in start
    with venv(Path(checkout_dir) / self.feedstock_subdir / "requirements.txt"):
  File "/Users/lsterzin/miniconda3/envs/work/lib/python3.11/contextlib.py", line 137, in __enter__
    return next(self.gen)
           ^^^^^^^^^^^^^^
  File "/Users/lsterzin/miniconda3/envs/work/lib/python3.11/site-packages/venvception/venv.py", line 30, in venv
    raise FileNotFoundError(f"{requirements_file} does not exist.")
FileNotFoundError: feedstock/requirements.txt does not exist.
```

I added a feedstock with `pangeo-forge-recipes` as well as the specific packages needed by `zarr_recipe.py`. Though some of those may already be dependencies of `pangeo-forge-recipes`.